### PR TITLE
[Rollbar/Classic#95085] Add logging to debug nil response body

### DIFF
--- a/lib/twitter/rest/request.rb
+++ b/lib/twitter/rest/request.rb
@@ -54,7 +54,7 @@ module Twitter
         end
         @rate_limit = Twitter::RateLimit.new(response.response_headers)
         body = response.body
-        log("Twitter response body nil. Time taken: #{duration}, Status: #{response.status}, Headers: #{response.response_headers}") if body.nil?
+        log("Twitter response body nil. URI: #{@uri}, Time taken: #{duration}, Status: #{response.status}, Headers: #{response.response_headers}") if body.nil?
         body
       end
     end


### PR DESCRIPTION
/cc @smedberg 

### Description

Adds logging to retrieve more info on a nil request.body.

### References

Rollbar exceptions: https://rollbar-us.zendesk.com/Zendesk/Classic/items/95085/

### Risks

Low: Logging added.

